### PR TITLE
Compose file improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SPRING_REDIS_USER=default
+SPRING_REDIS_PASSWORD=JiraConnectorRedisDB

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Editor files
+.vscode/
+
+# Secret files
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
 
 networks:
     qualys-jira-connector:
+        attachable: false
 
 volumes:
     qualys-jira-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
         environment:
             - SPRING_REDIS_HOST=#vm_ip_address
             - SPRING_REDIS_PORT=6379
-            - SPRING_REDIS_USER=default
-            - SPRING_REDIS_PASSWORD=JiraConnectorRedisDB
+            - SPRING_REDIS_USER=${SPRING_REDIS_USER:-default}
+            - SPRING_REDIS_PASSWORD=${SPRING_REDIS_PASSWORD:-JiraConnectorRedisDB}
 
     redis-client-service:
         image: qualys/redis-client-for-jira-integration:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         networks:
             - qualys-jira-connector
         volumes:
-            - qualys-jira-volume:/opt/qualys/common/jiraconnector/ 
+            - qualys-jira-volume:/opt/qualys/common/jiraconnector/
         environment:
             - SPRING_REDIS_HOST=#vm_ip_address
             - SPRING_REDIS_PORT=6379
@@ -17,9 +17,9 @@ services:
         networks:
             - qualys-jira-connector
         ports:
-          - 6379:6379
+            - 6379:6379
         volumes:
-          - qualys-jira-volume:/opt/qualys/common/jiraconnector/     
+            - qualys-jira-volume:/opt/qualys/common/jiraconnector/
 
     jira-client-service:
         image: qualys/jira-client-for-jira-integration:1.1.0
@@ -35,4 +35,4 @@ networks:
     qualys-jira-connector:
 
 volumes:
-  qualys-jira-volume:
+    qualys-jira-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
         container_name: qualys-jira-redis-client-service
         networks:
             - qualys-jira-connector
-        ports:
-            - 6379:6379
         volumes:
             - qualys-jira-volume:/opt/qualys/common/jiraconnector/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,14 @@ services:
         volumes:
             - qualys-jira-volume:/opt/qualys/common/jiraconnector/
         environment:
-            - SPRING_REDIS_HOST=#vm_ip_address
+            - SPRING_REDIS_HOST=qualys-jira-redis-client-service
             - SPRING_REDIS_PORT=6379
             - SPRING_REDIS_USER=${SPRING_REDIS_USER:-default}
             - SPRING_REDIS_PASSWORD=${SPRING_REDIS_PASSWORD:-JiraConnectorRedisDB}
 
     redis-client-service:
         image: qualys/redis-client-for-jira-integration:latest
+        container_name: qualys-jira-redis-client-service
         networks:
             - qualys-jira-connector
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.1"
 services:
     qualys-client-service:
         image: qualys/qualys-client-for-jira-integration:1.1.0
+        container_name: qualys-jira-qualys-client
         networks:
             - qualys-jira-connector
         volumes:
@@ -22,6 +23,7 @@ services:
 
     jira-client-service:
         image: qualys/jira-client-for-jira-integration:1.1.0
+        container_name: qualys-jira-jira-client
         networks:
             - qualys-jira-connector
         volumes:


### PR DESCRIPTION
### Main changes
This PR implements the following changes:

* Explicitly denies attachment of the network to containers outside of the compose file
* Changes the redis container and Qualys client to communicate over the Docker network directly (prevents users from having to input IP of the host manually, ensures container communication is done over internal Docker network)
* Removes port mapping of redis port to host port (reduces open ports on host since all redis communication is now internal on the Docker network)
* Moves "secret" values to `.env` file, or uses defaults if no such file exists
* General formatting fixes (my vscode was yelling at me about it, sorry 😅)
* Add `.gitignore` file to ignore vscode files and the `.env` secret file

### Other issues I've identified
Currently, only the Qualys Client accepts a username and password for Redis. To increase security, it is recommended to also allow control of these credentials on the Redis container (and any other container that will communicate with redis), such as a set of environment variables like the Qualys Client has. This would allow users to specify their own set of credentials in the `.env` file as to not use the defaults found in this repo.

### Potential issues caused by this PR
The setting of `container_name` may conflict with other containers if they have the same name as this setting causes Docker to no longer respect the parent folder it is in to assign a name to the containers.

The user guide will need to be updated to reflect the `.env` file changes, should a user wish to use their own set of credentials instead of the default. For example, users would need to either copy or rename `.env.example` to `.env` and change permissions so only the owner can read/write to it (`chmod 0600 .env`, for example)