### PR TITLE
Simplify the connector deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.4"
 services:
     qualys-client-service:
         image: qualys/qualys-client-for-jira-integration:1.3.2.1
+        restart: always
         networks:
             - qualys-jira-connector
         volumes:
@@ -14,6 +15,7 @@ services:
 
     redis-client-service:
         image: qualys/redis-client-for-jira-integration:1.2.1
+        restart: always
         networks:
             - qualys-jira-connector
         ports:
@@ -23,6 +25,7 @@ services:
 
     jira-client-service:
         image: qualys/jira-client-for-jira-integration:1.3.2.1
+        restart: always
         networks:
             - qualys-jira-connector
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         volumes:
             - qualys-jira-volume:/opt/qualys/common/jiraconnector/ 
         environment:
-            - SPRING_REDIS_HOST=#vm_ip_address of the host on which Jira Connector is running
+            - SPRING_REDIS_HOST=redis-client-service
             - SPRING_REDIS_PORT=6379
             - SPRING_REDIS_USER=default
             - SPRING_REDIS_PASSWORD=JiraConnectorRedisDB
@@ -28,7 +28,7 @@ services:
         volumes:
             - qualys-jira-volume:/opt/qualys/common/jiraconnector/
         environment:
-            - SPRING_REDIS_HOST=#vm_ip_address of the host on which Jira Connector is running
+            - SPRING_REDIS_HOST=redis-client-service
             - SPRING_REDIS_PORT=6379
             - SPRING_REDIS_USER=default
             - SPRING_REDIS_PASSWORD=JiraConnectorRedisDB    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
         restart: always
         networks:
             - qualys-jira-connector
-        ports:
-          - 6379:6379
         volumes:
           - qualys-jira-volume:/opt/qualys/common/jiraconnector/     
 


### PR DESCRIPTION
All these changes will allow customers to use docker-compose.yml without any modifications from their side and simplifies the deployment. 